### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ version = "0.1.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 LsqFit = "0.13"
 RecipesBase = "1"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.8"
 
 [extras]

--- a/src/SinusoidalRegressions.jl
+++ b/src/SinusoidalRegressions.jl
@@ -2,7 +2,7 @@ module SinusoidalRegressions
 
 using LsqFit
 using RecipesBase
-using SnoopPrecompile
+using PrecompileTools
 using Zygote
 using LinearAlgebra
 
@@ -111,12 +111,12 @@ Convert polar coordinates to rectangular coordinates `(y, x)` where ``x = M\\cos
 torect(M, θ) = (-M*sin(θ), M*cos(θ))
 #=
 ## Precompilation
-@precompile_setup begin
+@setup_workload begin
     x = [-1.983, -1.948, -1.837, -1.827, -1.663, -0.815, -0.778, -0.754, -0.518,  0.322,  0.418,  0.781,
           0.931,  1.510,  1.607]
     y = [ 0.936,  0.810,  0.716,  0.906,  0.247, -1.513, -1.901, -1.565, -1.896,  0.051,  0.021,  1.069,
           0.862,  0.183,  0.311] 
-    @precompile_all_calls begin
+    @compile_workload begin
         t2 = ieee1057(x, y)
         t1 = ieee1057(x, y, 1.5)
         t3 = sinfit_j(x, y)


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
